### PR TITLE
Cleanup After Dependency Upgrade Struggle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Build the project
         run: npm run build
 
-      - name: List contents of dist directory
-        run: ls -la ./dist
-
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -39,11 +36,3 @@ jobs:
           publish_branch: gh-pages
           enable_jekyll: false
           cname: waylon.app
-
-      - name: Verify files in the gh-pages branch
-        run: |
-          git fetch origin gh-pages
-          git ls-tree -r origin/gh-pages --name-only
-
-      - name: List contents of deployment directory
-        run: ls -la /home/runner/actions_github_pages_*

--- a/README.md
+++ b/README.md
@@ -165,5 +165,3 @@ This app will utilize the WebAudio API to allow users to interact via their micr
   * Translation: "Breathing is for chumps!"
   * Translation: CENSORED
 * "Embarrassment-Free Mode" - with button controls (in case people around user are staring at them as they make whale noises)
-
-ugh this thing has gotten so screwed up

--- a/index.html
+++ b/index.html
@@ -35,11 +35,11 @@
         <ul class="profile-link-list">
           <a class="profile-link" href="https://matthewgreer.github.io/" target=" ">
             <li class="profile-list-item">
-              <img src="./images/mg-net-link-icon.png"
+              <img src="/images/mg-net-link-icon.png"
                 class="profile-link-image mg-net-link-icon"
                 alt="MatthewGreer.net Logo"
               />
-              <img src="./images/mg-net-link-icon-hover.png"
+              <img src="/images/mg-net-link-icon-hover.png"
                 class="profile-link-image-hover mg-net-link-icon-hover"
                 alt="MatthewGreer.net Logo"
               />
@@ -47,13 +47,13 @@
           </a>
           <a class="profile-link" href="https://github.com/matthewgreer/waylon" target=" ">
             <li class="profile-list-item">
-              <img src="./images/github-icon.png"
+              <img src="/images/github-icon.png"
                 class="profile-link-image github-icon"
                 alt="GitHub Octocat Logo"
               />
             </li>
             <li class="profile-list-item">
-              <img src="./images/github-icon-hover.png"
+              <img src="/images/github-icon-hover.png"
                 class="profile-link-image-hover github-icon-hover"
                 alt="GitHub Octocat Logo"
               />
@@ -61,13 +61,13 @@
           </a>
           <a class="profile-link" href="https://www.linkedin.com/in/matthewgreerdev/" target=" ">
             <li class="profile-list-item">
-              <img src="./images/linkedin-icon.png"
+              <img src="/images/linkedin-icon.png"
                 class="profile-link-image linkedin-icon"
                 alt="LinkedIn Logo"
               />
             </li>
             <li class="profile-list-item">
-              <img src="./images/linkedin-icon-hover.png"
+              <img src="/images/linkedin-icon-hover.png"
                 class="profile-link-image-hover linkedin-icon-hover"
                 alt="LinkedIn Logo"
               />

--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
     <div class="maintain-aspect-ratio">
       <main>
         <header>
-          <!-- <p id="freq-display"></p> --><!-- for debugging, displays current sound freq -->
+          <!-- uncomment for debugging, displays current evaluated sound freq -->
+          <!-- <p id="freq-display"></p> -->
           <div id="score" class="header-section"></div>
           <div class="header-section">
             <img src="/images/waylon-title-logo.svg"


### PR DESCRIPTION
After much ado, I finally got our whale friend back on Prod. 

## Some Learnings:
- Hosting multiple projects via GitHub pages can be hinky
  - Deploying from branch `gh-pages` removed Waylon's custom URL
- Webpack tips:
  -  `output.publicPath` should be set to `'/'`
  - `HtmlWebpackPlugin` should be `inject: true`
  - `CopyWebpackPlugin` 
    - copy `.nojekyll` and `CNAME` files over to `/dist`
    - not essential for dev (though it gets rid of a pesky console warning), but `site.manifest` should also be copied over to `/dist` for prod
- `src` in `HTML` file
  - Works best if it's `src="/images/filename.ext"`
- Best to Deploy Via Custom GitHub Actions Workflow
  - **VERY IMPORTANT: include `jobs.build.environment: github-pages`!**
  - Took me forever to figure that one out.
  - Can use `peaceiris/actions-gh-pages` Action
    - explicitly pass `cname: waylon.app` as well as `enable_jekyll: false`
    - make sure `publish_branch` is `gh-pages`
  - Used some temporary steps in the custom workflow (`deploy.yml`) to debug:
``` yaml
- name: List contents of dist directory
   run: ls -la ./dist

- name: Verify files in the gh-pages branch
   run: |
     git fetch origin gh-pages
     git ls-tree -r origin/gh-pages --name-only

- name: List contents of deployment directory
   run: ls -la /home/runnier/actions_github_pages_*
```

## This PR
- cleans up temporary debugging steps in `deploy.yml` workflow
- removes whiney complaint tacked on the end of `README.md` to trigger redeploy
- although they still compiled properly, changed `"./images/filename.ext"` to `"/images/filename.ext"` for `<img src=`
- shifts the comment around the frequency displayer (for debugging porpoises only)