### PR TITLE
Remove CleanWebpackPlugin (deprecated dependencies)

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
@@ -14,7 +13,6 @@ module.exports = {
         publicPath: '/',
     },
     plugins: [
-        new CleanWebpackPlugin(),
         new HtmlWebpackPlugin({
             template: './index.html',
             inject: true,


### PR DESCRIPTION
Since the `deploy.yml` custom GitHub Actions workflow has a step that drops the old `/dist` directory, this plugin is redundant. Plus, even its latest version's got deprecated dependencies:
```
|-- clean-webpack-plugin@4.0.0
|  |-- del@4.1.1
|     |-- globby@6.1.0
|     |   |-- glob@7.2.3 * deprecated version
|     |      |-- inflight@1.0.6 * memory leak -- do not use
|     |-- rimraf@2.7.1 * deprecated version
|        |-- glob@7.2.3 * deprecated version
|           |-- inflight@1.0.6 (deduped)
|-- glob@9.3.5 * latest
   |-- rimraf@4.4.1 * latest
      |-- glob@9.3.5 (deduped)
```

This PR removes the plugin.